### PR TITLE
Bump CI Node version from 18 to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node
         uses: volta-cli/action@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install pnpm
         run: volta install pnpm@10
       - name: Install Dependencies
@@ -41,7 +41,7 @@ jobs:
       - name: Install Node
         uses: volta-cli/action@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install pnpm
         run: volta install pnpm@10
       - name: Install Dependencies
@@ -70,7 +70,7 @@ jobs:
       - name: Install Node
         uses: volta-cli/action@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install pnpm
         run: volta install pnpm@10
       - name: Install Dependencies


### PR DESCRIPTION
## Summary
- Bump `node-version` in `.github/workflows/ci.yml` from `18` to `20` for all three jobs (`test`, `floating`, `try-scenarios`)
- Aligns CI with the repo's declared `engines.node` (`>= 20.11`) and local `volta.node` pin (`20.19.2`)

## Why
The `Floating Dependencies`, `ember-canary`, and `ember-beta` jobs have been failing because several transitive deps have raised their minimum Node requirement past 18, including:

- `ember-cli@6.9.1` → `>= 20.19.0`
- `ember-cli-htmlbars@7.0.1` → `>= 20`
- `broccoli@4.0.0` → `>= 20.19.*`
- `testem@3.20.0` → `^20.19.0 || ^22.12.0 || >=24`
- `chokidar@5.0.0`, `readdirp@5.0.0` → `>= 20.19.0`

The pinned-version jobs currently pass only because the lockfile still resolves older, Node-18-compatible versions. Floating/canary/beta resolve to current latest, which breaks on Node 18.

## Test plan
- [ ] CI `Tests` passes on Node 20
- [ ] CI `Floating Dependencies` passes on Node 20
- [ ] CI `ember-canary`, `ember-beta`, `ember-lts-5.12`, `ember-release`, `embroider-safe` all pass on Node 20

https://claude.ai/code/session_01449Kg7hGN4YmzR3TZEECWP