### PR TITLE
Add ember-6 try-scenario as the required Ember compatibility check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       matrix:
         try-scenario:
           - ember-lts-5.12
+          - ember-6
           - ember-release
           - ember-beta
           - ember-canary

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -16,6 +16,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-6',
+        npm: {
+          devDependencies: {
+            'ember-source': '^6.0.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
## Why

The `ember-release` channel now serves **Ember 7**, which this classic v1 addon cannot build against yet (the classic broccoli build fails in ember-cli's builder). Since `ember-release` is a required status check, every open Dependabot PR is blocked regardless of what it bumps.

## What

- Adds an `ember-6` ember-try scenario that tests against the latest Ember 6.x release (`ember-source: ^6.0.0`)
- Adds `ember-6` to the CI try-scenario matrix

After this merges, branch protection will require `ember-6` instead of `ember-release`, leaving `ember-release` / `ember-beta` / `ember-canary` as informational until Ember 7 support lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)